### PR TITLE
Minor README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ANSI / Xterm 256 color library for Dart
 
 Feel like you're missing some color in your terminal programs? Use AnsiPen to add ANSI color codes to your log messages.  
 
-Easy to disable for production, just set `color_disabled = false` and all codes will be empty - no re-writing debug messages.  
+Easy to disable for production, just set the global `color_disabled = true` and all codes will be empty - no re-writing debug messages.  
 
 Example
 ------


### PR DESCRIPTION
Set color_disabled to true in order to disable colors (the README current say false).

Also be explicit that color_disabled is a global. I had thought it might be a static property on AnsiPen.
