### PR TITLE
Explicitly Enable Strong Mode Analysis

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,2 @@
+analyzer:
+  strong-mode: true


### PR DESCRIPTION
Enabling Strong Mode analysis ensures that the package is compatible with the Dart Dev Compiler. By maintaining a the `analysis_options.yaml` file it is possible for tooling to audit strong mode compliance throughout the dependency graph of a dart application. 

The implementation is currently strong mode complaint and requires no code changes:

```
dartanalyzer --verbose --fatal-infos --fatal-warnings lib/ansicolor.dart test/ansicolor_test.dart
Analyzing lib/ansicolor.dart, test/ansicolor_test.dart...
Loaded analysis options from /tmp/ansicolor-dart/analysis_options.yaml
No issues found!
```