### PR TITLE
Use package import in demo.dart

### DIFF
--- a/bin/demo.dart
+++ b/bin/demo.dart
@@ -1,4 +1,4 @@
-import '../lib/ansicolor.dart';
+import 'package:ansicolor/ansicolor.dart';
 
 main() {
   print(ansi_demo());


### PR DESCRIPTION
This is needed for bazel builds when compiling the demo separately from the library.