### PR TITLE
Update for Dart 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ packages
 pubspec.lock
 .project
 .children
+.dart_tool
+.packages
 *~

--- a/lib/ansicolor.dart
+++ b/lib/ansicolor.dart
@@ -32,11 +32,11 @@ class AnsiPen {
 
     StringBuffer sb = new StringBuffer();
     if (_fcolor != null) {
-      sb.write("${ANSI_ESC}38;5;${_fcolor}m");
+      sb.write("${ansi_esc}38;5;${_fcolor}m");
     }
 
     if (_bcolor != null) {
-      sb.write("${ANSI_ESC}48;5;${_bcolor}m");
+      sb.write("${ansi_esc}48;5;${_bcolor}m");
     }
 
     _pen = sb.toString();
@@ -47,7 +47,7 @@ class AnsiPen {
   String get down => this.toString();
 
   /// Resets all pen attributes in the terminal.
-  String get up => color_disabled ? "" : ANSI_DEFAULT;
+  String get up => color_disabled ? "" : ansi_default;
 
   /// Write the [msg] with the pen's current settings and then reset all
   /// attributes.
@@ -100,15 +100,15 @@ class AnsiPen {
 }
 
 /// ANSI Control Sequence Introducer, signals the terminal for new settings.
-String get ANSI_ESC => color_disabled ? "" : '\x1B[';
+String get ansi_esc => color_disabled ? "" : '\x1B[';
 
 /// Reset all colors and options for current SGRs to terminal defaults.
-String get ANSI_DEFAULT => color_disabled ? "" : "${ANSI_ESC}0m";
+String get ansi_default => color_disabled ? "" : "${ansi_esc}0m";
 
 /// Defaults the terminal's foreground color without altering the background.
 /// Does not modify [AnsiPen]!
-String resetForeground() => "${ANSI_ESC}39m";
+String resetForeground() => "${ansi_esc}39m";
 
 /// Defaults the terminal's background color without altering the foreground.
 /// Does not modify [AnsiPen]!
-String resetBackground() => "${ANSI_ESC}49m";
+String resetBackground() => "${ansi_esc}49m";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,9 @@
 name: ansicolor
-version: 0.1.1
+version: 1.0.0
 author: John Thomas McDole <codefu@google.com>
 description: An xterm 256 color support library
 homepage: https://github.com/google/ansicolor-dart
 environment:
-  sdk: ">=1.0.0 <2.0.0"
+  sdk: ">=2.0.0-dev.36.0 <3.0.0"
 dev_dependencies:
   test: ">=0.12.18"

--- a/src/demo.dart
+++ b/src/demo.dart
@@ -1,5 +1,0 @@
-import "../lib/ansicolor.dart";
-
-void main() {
-  print(ansi_demo());
-}


### PR DESCRIPTION
Changed constants from SCREAMING_CAPS to normal_identifiers (per Dart
2.0 style).

Update required SDK and bump version to 1.0.0 in pubspec.yaml.