### PR TITLE
Resolve some old standing issues

### DIFF
--- a/example/ansicolor.dart
+++ b/example/ansicolor.dart
@@ -1,6 +1,7 @@
 import 'package:ansicolor/ansicolor.dart';
 
 void main() {
+  ansiColorDisabled = false;
   print(ansi_demo());
 }
 

--- a/lib/ansicolor.dart
+++ b/lib/ansicolor.dart
@@ -7,10 +7,17 @@
 ///     AnsiConsol plugins!
 library ansicolor;
 
-/// Globally enable or disable [AnsiPen] settings
+/// Globally enable or disable [AnsiPen] settings.
 ///
 /// Handy for turning on and off embedded colors without commenting out code.
-bool color_disabled = false;
+bool ansiColorDisabled = false;
+
+@Deprecated(
+    'Will be removed in future releases in favor of [ansiColorDisabled]')
+bool get color_disabled => ansiColorDisabled;
+@Deprecated(
+    'Will be removed in future releases in favor of [ansiColorDisabled]')
+set color_disabled(bool disabled) => ansiColorDisabled = disabled;
 
 /// Pen attributes for foreground and background colors.
 ///
@@ -27,16 +34,16 @@ class AnsiPen {
   ///     changed by another pen or [up].
   @override
   String toString() {
-    if (color_disabled) return '';
+    if (ansiColorDisabled) return '';
     if (!_dirty) return _pen;
 
     final sb = StringBuffer();
     if (_fcolor != -1) {
-      sb.write('${ansi_esc}38;5;${_fcolor}m');
+      sb.write('${ansiEscape}38;5;${_fcolor}m');
     }
 
     if (_bcolor != -1) {
-      sb.write('${ansi_esc}48;5;${_bcolor}m');
+      sb.write('${ansiEscape}48;5;${_bcolor}m');
     }
 
     _dirty = false;
@@ -48,7 +55,7 @@ class AnsiPen {
   String get down => '${this}';
 
   /// Resets all pen attributes in the terminal.
-  String get up => color_disabled ? '' : ansi_default;
+  String get up => ansiColorDisabled ? '' : ansiDefault;
 
   /// Write the [msg.toString()] with the pen's current settings and then
   /// reset all attributes.
@@ -103,15 +110,31 @@ class AnsiPen {
 }
 
 /// ANSI Control Sequence Introducer, signals the terminal for new settings.
-String get ansi_esc => color_disabled ? '' : '\x1B[';
+const ansiEscape = '\x1B[';
+
+@Deprecated('Will be removed in future releases')
+const ansi_esc = ansiEscape;
 
 /// Reset all colors and options for current SGRs to terminal defaults.
-String get ansi_default => color_disabled ? '' : '${ansi_esc}0m';
+const ansiDefault = '${ansiEscape}0m';
 
-/// Defaults the terminal's foreground color without altering the background.
-/// Does not modify [AnsiPen]!
-String resetForeground() => '${ansi_esc}39m';
+@Deprecated('Will be removed in future releases')
+const ansi_default = ansiDefault;
 
-/// Defaults the terminal's background color without altering the foreground.
+/// Ansi codes that default the terminal's foreground color without
+/// altering the background, when printed.
+///
 /// Does not modify [AnsiPen]!
-String resetBackground() => '${ansi_esc}49m';
+const ansiResetForeground = '${ansiEscape}39m';
+
+@Deprecated('Will be removed in future releases')
+String resetForeground() => ansiResetForeground;
+
+///Ansi codes that default the terminal's background color without
+///altering the foreground, when printed.
+///
+/// Does not modify [AnsiPen]!
+const ansiResetBackground = '${ansiEscape}49m';
+
+@Deprecated('Will be removed in future releases')
+String resetBackground() => ansiResetBackground;

--- a/lib/ansicolor.dart
+++ b/lib/ansicolor.dart
@@ -19,7 +19,7 @@ bool color_disabled = false;
 class AnsiPen {
   /// Treat a pen instance as a function such that `pen('msg')` is the same as
   /// `pen.write('msg')`.
-  String call(String msg) => write(msg);
+  String call(Object msg) => write(msg);
 
   /// Allow pen colors to be used in a string.
   ///
@@ -50,9 +50,9 @@ class AnsiPen {
   /// Resets all pen attributes in the terminal.
   String get up => color_disabled ? '' : ansi_default;
 
-  /// Write the [msg] with the pen's current settings and then reset all
-  /// attributes.
-  String write(String msg) => '${this}$msg$up';
+  /// Write the [msg.toString()] with the pen's current settings and then
+  /// reset all attributes.
+  String write(Object msg) => '${this}$msg$up';
 
   void black({bool bg = false, bool bold = false}) => _std(0, bold, bg);
   void red({bool bg = false, bool bold = false}) => _std(1, bold, bg);

--- a/lib/ansicolor.dart
+++ b/lib/ansicolor.dart
@@ -7,10 +7,16 @@
 ///     AnsiConsol plugins!
 library ansicolor;
 
+import 'src/supports_ansi.dart'
+    if (dart.library.io) 'src/supports_ansi_io.dart'
+    if (dart.library.html) 'src/supports_ansi_web.dart';
+
 /// Globally enable or disable [AnsiPen] settings.
 ///
+/// Note: defaults to environment support; but can be overridden.
+///
 /// Handy for turning on and off embedded colors without commenting out code.
-bool ansiColorDisabled = false;
+bool ansiColorDisabled = !supportsAnsiColor;
 
 @Deprecated(
     'Will be removed in future releases in favor of [ansiColorDisabled]')

--- a/lib/src/supports_ansi.dart
+++ b/lib/src/supports_ansi.dart
@@ -1,0 +1,1 @@
+bool get supportsAnsiColor => false;

--- a/lib/src/supports_ansi_io.dart
+++ b/lib/src/supports_ansi_io.dart
@@ -1,0 +1,3 @@
+import 'dart:io';
+
+bool get supportsAnsiColor => stdout.supportsAnsiEscapes;

--- a/lib/src/supports_ansi_web.dart
+++ b/lib/src/supports_ansi_web.dart
@@ -1,0 +1,3 @@
+// Well, true for new versions of the browser; would be great to
+// test if console.print() supported it.
+bool get supportsAnsiColor => true;

--- a/test/ansicolor_test.dart
+++ b/test/ansicolor_test.dart
@@ -3,6 +3,7 @@ library ansicolor_test;
 import 'package:ansicolor/ansicolor.dart';
 import 'package:test/test.dart';
 
+@TestOn('dart-vm')
 void main() {
   setUp(() {
     ansiColorDisabled = false;

--- a/test/ansicolor_test.dart
+++ b/test/ansicolor_test.dart
@@ -4,8 +4,12 @@ import 'package:ansicolor/ansicolor.dart';
 import 'package:test/test.dart';
 
 void main() {
+  setUp(() {
+    ansiColorDisabled = false;
+  });
+
   tearDown(() {
-    color_disabled = false;
+    ansiColorDisabled = false;
   });
 
   test('foreground', () {
@@ -30,7 +34,8 @@ void main() {
     final pen = AnsiPen()
       ..rgb(r: 1.0, g: 0.8, b: 0.2)
       ..rgb(r: 0.4, g: 0.8, b: 1.0, bg: true);
-    expect(pen.write('Test${resetBackground()} Text${resetForeground()}Test'),
+    expect(
+        pen.write('Test${ansiResetBackground} Text${ansiResetForeground}Test'),
         '\x1B[38;5;221m\x1B[48;5;117mTest\x1B[49m Text\x1B[39mTest\x1B[0m');
   });
 
@@ -127,12 +132,11 @@ void main() {
     }
   });
 
-  test('color_disabled', () {
-    color_disabled = false;
+  test('ansiColorDisabled', () {
     final pen = AnsiPen()
       ..rgb(r: 1.0, g: 0.8, b: 0.2)
       ..rgb(r: 0.4, g: 0.8, b: 1.0, bg: true);
-    color_disabled = true;
+    ansiColorDisabled = true;
     expect(pen.write('Test Text'), 'Test Text');
   });
 }

--- a/test/browser_test.dart
+++ b/test/browser_test.dart
@@ -1,0 +1,16 @@
+import 'package:ansicolor/ansicolor.dart';
+import 'package:test/test.dart';
+
+@TestOn('browser')
+void main() {
+  setUp(() {
+    ansiColorDisabled = false;
+  });
+
+  tearDown(() {
+    ansiColorDisabled = false;
+  });
+  test('browser compiles', () {
+    expect(ansiColorDisabled, isFalse);
+  });
+}


### PR DESCRIPTION
1. Accept `Object` for call and write methods
2. Update globals (with backwards support / deprecation)
3. Default to terminal support