### PR TITLE
Upgrade to null_safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 1.1.0
 
 * Round up release closing out some older issues.
-  * Try to detect is ANSI is supported
+  * Try to detect if ANSI is supported
   * Update naming style; deprecate the old names.
   * write() and call() take object now.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety.0
+
+* pre-release with support for [null_safety](https://dart.dev/null-safety/migration-guide).
+
 ## 1.1.0
 
 * Round up release closing out some older issues.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: ansicolor
-version: 1.1.0
+version: 2.0.0-nullsafety.0
 description: >-
   Looking to add some color to your terminal logs? `ansicolor` is an xterm-256
   color support library that lets you change the foreground and background
   color of your text.
 homepage: https://github.com/google/ansicolor-dart
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: '>=2.12.0-29.10.beta <3.0.0'
 dev_dependencies:
-  test: ">=0.12.18"
+  test: ">=1.16.0-nullsafety.12"


### PR DESCRIPTION
Hey, I thought you might want to publish your package with null_safety support.

I did the migration for you and incredibly, all your code was already null safe 👍 .

So all I had to do was change the pub spec and release notes.

You can check that I've followed the instructions given by the Dart docs: https://dart.dev/null-safety/migration-guide

As [I have a package](https://pub.dev/packages/dartle) that depends on your package, I would appreciate if you could publish this version.

Thanks in advance!