### PR TITLE
Move TestOn annotations to the library level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.2-dev
+
 ## 2.0.1
 
 * Update to default `2.12.0` for null safety before publishing.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: ansicolor
-version: 2.0.1
+version: 2.0.2-dev
 description: >-
   Looking to add some color to your terminal logs? `ansicolor` is an xterm-256
   color support library that lets you change the foreground and background
   color of your text.
-homepage: https://github.com/google/ansicolor-dart
+repository: https://github.com/google/ansicolor-dart
 environment:
   sdk: ">=2.12.0 <3.0.0"
 dev_dependencies:

--- a/test/ansicolor_test.dart
+++ b/test/ansicolor_test.dart
@@ -1,9 +1,9 @@
+@TestOn('dart-vm')
 library ansicolor_test;
 
 import 'package:ansicolor/ansicolor.dart';
 import 'package:test/test.dart';
 
-@TestOn('dart-vm')
 void main() {
   setUp(() {
     ansiColorDisabled = false;

--- a/test/browser_test.dart
+++ b/test/browser_test.dart
@@ -1,7 +1,8 @@
+@TestOn('browser')
+
 import 'package:ansicolor/ansicolor.dart';
 import 'package:test/test.dart';
 
-@TestOn('browser')
 void main() {
   setUp(() {
     ansiColorDisabled = false;


### PR DESCRIPTION
These annotations are only read at the library level. The next version
of the test package configures the `Target` for this annotation so the
analyzer will raise diagnostics for these incorrect usages.