### PR TITLE
Add public color getters to AnsiPen

### DIFF
--- a/lib/ansicolor.dart
+++ b/lib/ansicolor.dart
@@ -113,6 +113,15 @@ class AnsiPen {
     _bcolor = _fcolor = -1;
   }
 
+  /// Get the foreground color index.
+  int get fcolor => _fcolor;
+
+  /// Get the background color index.
+  int get bcolor => _bcolor;
+
+  /// Get whether the pen attributes are dirty.
+  bool get dirty => _dirty;
+
   int _fcolor = -1;
   int _bcolor = -1;
   String _pen = '';

--- a/lib/ansicolor.dart
+++ b/lib/ansicolor.dart
@@ -113,13 +113,13 @@ class AnsiPen {
     _bcolor = _fcolor = -1;
   }
 
-  /// Get the foreground color index.
+  /// Returns the pen's foreground color
   int get fcolor => _fcolor;
 
-  /// Get the background color index.
+  /// Returns the pen's background color index.
   int get bcolor => _bcolor;
 
-  /// Get whether the pen attributes are dirty.
+  /// Returns whether the pen's attributes are dirty.
   bool get dirty => _dirty;
 
   int _fcolor = -1;


### PR DESCRIPTION
Hello @jtmcdole 👋
I need to determine the current color configuration set of AnsiPen in my logger package [talker](https://pub.dev/packages/talker) 
(that package uses ansicolor for colorful console logs)

However, the **_fcolor**, **_bcolor**, and **_dirty** is private fields.
Is it possible to provide external access to retrieve this information using getters?