### PR TITLE
Add `topics` to `pubspec.yaml`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,3 +10,5 @@ environment:
 dev_dependencies:
   lints: ^2.1.1
   test: ^1.16.8
+topics:
+ - cli


### PR DESCRIPTION
Topics helps users on pub.dev discover packages, and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to `pubspec.yaml` as follows:

```yaml
topics:
 - my-topic
 - some-other-topic
```

See also: https://dart.dev/tools/pub/pubspec#topics