### PR TITLE
Add Wasm support

### DIFF
--- a/lib/ansicolor.dart
+++ b/lib/ansicolor.dart
@@ -9,7 +9,7 @@ library ansicolor;
 
 import 'src/supports_ansi.dart'
     if (dart.library.io) 'src/supports_ansi_io.dart'
-    if (dart.library.html) 'src/supports_ansi_web.dart';
+    if (dart.library.js_interop) 'src/supports_ansi_web.dart';
 
 /// Globally enable or disable [AnsiPen] settings.
 ///


### PR DESCRIPTION
Since dart:html is not supported when compiling to Wasm, the correct alternative now is to use dart.library.js_interop to differentiate between native and web

Source:
https://dart.dev/interop/js-interop/package-web